### PR TITLE
setup benchmarking against RABL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ gemspec
 
 gem 'rake'
 gem 'pry'
+gem "whysoslow"
+
+gem 'rabl'
 
 platform :rbx do
   gem 'rubysl'

--- a/bench/results.txt
+++ b/bench/results.txt
@@ -1,0 +1,40 @@
+RABL slideshow: 1 times
+-----------------------
+whysoslow? ..
+
+mem @ start             31 MB                   ??
+mem @ finish            31 MB                   [31m+   0 MB,   0%[0m
+
+         user     system   total    real
+time     0.0 ms   0.0 ms   0.0 ms   2.686 ms
+
+RABL slideshow: 10 times
+------------------------
+whysoslow? ..
+
+mem @ start             41 MB                   ??
+mem @ finish            41 MB                   [31m+   0 MB,   0%[0m
+
+          user      system    total     real
+time      20.0 ms   10.0 ms   30.0 ms   23.928 ms
+
+RABL slideshow: 100 times
+-------------------------
+whysoslow? ..
+
+mem @ start             41 MB                   ??
+mem @ finish            93 MB                   [31m+  52 MB, 129%[0m
+
+           user       system     total      real
+time       190.0 ms   40.0 ms    230.0 ms   228.245 ms
+
+RABL slideshow: 1000 times
+--------------------------
+whysoslow? ..
+
+mem @ start             68 MB                   ??
+mem @ finish            642 MB                  [31m+ 573 MB, 839%[0m
+
+            user        system      total       real
+time        1930.0 ms   310.0 ms    2240.0 ms   2235.501 ms
+

--- a/bench/runner.rb
+++ b/bench/runner.rb
@@ -1,0 +1,62 @@
+require 'whysoslow'
+require 'rabl'
+
+class Template
+
+  attr_reader :name, :locals
+
+  TEMPLATES = {}
+  require 'bench/slideshow'
+
+  def self.find(name)
+    TEMPLATES[name].new
+  end
+
+end
+
+class Runner
+
+  attr_reader :result
+
+  RUNNERS = {}
+
+  def self.run(runner, *args)
+    RUNNERS[runner].new(*args).run
+  end
+
+  def initialize(printer_io, title, num_times, &run_proc)
+    @proc = proc do
+      num_times.times do
+        run_proc.call
+      end
+    end
+
+    @printer = Whysoslow::DefaultPrinter.new(printer_io, {
+      :title => "#{title}: #{num_times} times",
+      :verbose => true
+    })
+    @runner = Whysoslow::Runner.new(@printer)
+  end
+
+  def run
+    @runner.run &@proc
+  end
+
+end
+
+class RablRunner < Runner
+
+  RUNNERS[:rabl] = self
+
+  def initialize(template_name, printer_io, num_times = 10)
+    template = Template.find(template_name)
+    super(printer_io, "RABL #{template.name}", num_times) do
+      out = Rabl::Renderer.new(template.name, nil, {
+        :view_path => File.expand_path('..', __FILE__),
+        :locals    => template.locals,
+        :format    => 'hash'
+      }).render
+    end
+  end
+
+end

--- a/bench/slideshow.nm
+++ b/bench/slideshow.nm
@@ -1,0 +1,12 @@
+node 'slideshow' do
+  node 'start_slide', view.start_slide
+  node 'slides' do
+    map view.slides do |slide|
+      node 'id',    slide.id
+      node 'image', slide.image_url
+      node 'thumb', slide.thumb_url
+      node 'title', slide.title
+      node 'url',   slide.url
+    end
+  end
+end

--- a/bench/slideshow.rabl
+++ b/bench/slideshow.rabl
@@ -1,0 +1,5 @@
+object locals[:view].slideshow => :slideshow
+attributes :start_slide
+child(:slides, :object_root => false, :root => :slides){
+  attributes :id, :title, :url, :image, :thumb
+}

--- a/bench/slideshow.rb
+++ b/bench/slideshow.rb
@@ -1,0 +1,42 @@
+require 'assert/factory'
+
+class SlideshowTemplate < Template
+
+  TEMPLATES[:slideshow] = self
+
+  def initialize
+    @name = 'slideshow'
+    @locals = { :view => View.new }
+  end
+
+  class View
+    attr_reader :start_slide, :slides
+
+    def initialize
+      @slides = (1..10).map{ |n| Slide.new(n) }
+      @start_slide = @slides.first.id
+    end
+
+    # for RABL template syntax needs
+    def slideshow
+      self
+    end
+  end
+
+  class Slide
+    attr_reader :id, :image_url, :thumb_url, :title, :url
+
+    def initialize(n)
+      @id = Assert::Factory.integer
+      @image_url = Assert::Factory.url
+      @thumb_url = Assert::Factory.url
+      @title = "Slide #{n}"
+      @url = Assert::Factory.url
+    end
+
+    # for RABL syntax needs
+    alias_method :image, :image_url
+    alias_method :thumb, :thumb_url
+  end
+
+end

--- a/script/bench.rb
+++ b/script/bench.rb
@@ -1,0 +1,45 @@
+# $ bundle exec ruby script/bench.rb
+
+# require pry for debugging (`binding.pry`)
+require 'pry'
+
+require 'bench/runner'
+
+class NmBenchLogger
+
+  def initialize(file_path)
+    @file = File.open(file_path, 'w')
+    @ios = [@file, $stdout]
+    yield self
+    @file.close
+  end
+
+  def method_missing(meth, *args, &block)
+    @ios.each do |io|
+      io.respond_to?(meth.to_s) ? io.send(meth.to_s, *args, &block) : super
+    end
+  end
+
+  def respond_to?(*args)
+    @ios.first.respond_to?(args.first.to_s) ? true : super
+  end
+
+end
+
+def run_template(runner, name, logger, *args)
+  GC.disable
+
+  Runner.run(runner, name, logger, *args)
+  logger.puts
+
+  GC.enable
+  GC.start
+end
+
+NmBenchLogger.new('bench/results.txt') do |logger|
+  run_template(:rabl, :slideshow, logger, 1)
+  run_template(:rabl, :slideshow, logger, 10)
+  run_template(:rabl, :slideshow, logger, 100)
+  run_template(:rabl, :slideshow, logger, 1000)
+end
+


### PR DESCRIPTION
Before we begin developing Nm, I want to have benchmarks in place
for a known templating system.  I am choosing RABL b/c I've used it
before and it does both JSON/BSON template outputs like Nm will.

This sets up running benchmarks using Whysoslow against a slideshow
template.  As Nm becomes ready, we can add it to the bench script
and see how it performs compared to RABL and make sure we aren't
introducing massive performance degredations.

@jcredding ready for review.
