### PR TITLE
api rename change: Template -> Render

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ end
 Render:
 
 ```ruby
-Nm::Template.new('/path/to/views/slideshow.json', {
+Nm::Render.new('/path/to/views/slideshow.json', {
   :start_slide => 1,
   :slides => [ ... ] #=> list of slide objects
 }).to_json

--- a/lib/nm/render.rb
+++ b/lib/nm/render.rb
@@ -1,6 +1,6 @@
 module Nm
 
-  class Template
+  class Render
 
     SOURCE_EXT = ".nm"
 

--- a/test/unit/render_tests.rb
+++ b/test/unit/render_tests.rb
@@ -1,11 +1,11 @@
 require 'assert'
-require 'nm/template'
+require 'nm/render'
 
-class Nm::Template
+class Nm::Render
 
   class UnitTests < Assert::Context
-    desc "Nm::Template"
-    subject{ Nm::Template }
+    desc "Nm::Render"
+    subject{ Nm::Render }
 
     should "know its source extension" do
       assert_equal ".nm", subject::SOURCE_EXT
@@ -17,21 +17,21 @@ class Nm::Template
     desc "when init"
     setup do
       @source_file = TEMPLATE_ROOT.join('slideshow').to_s
-      @template = Nm::Template.new(@source_file)
+      @template = Nm::Render.new(@source_file)
     end
     subject{ @template }
 
     should have_readers :source_file, :locals
 
     should "know its source file" do
-      exp = "#{@source_file}#{Nm::Template::SOURCE_EXT}"
+      exp = "#{@source_file}#{Nm::Render::SOURCE_EXT}"
       assert_equal exp, subject.source_file
     end
 
     should "complain if the source file does not exist" do
       no_exist_file = TEMPLATE_ROOT.join('does_not_exist')
       assert_raises ArgumentError do
-        Nm::Template.new(no_exist_file)
+        Nm::Render.new(no_exist_file)
       end
     end
 
@@ -42,7 +42,7 @@ class Nm::Template
 
     should "allow passing locals" do
       locals = { :some => 'val' }
-      template = Nm::Template.new(@source_file, locals)
+      template = Nm::Render.new(@source_file, locals)
       assert_equal locals, template.locals
     end
 


### PR DESCRIPTION
When trying to name the objects in play with this lib, I was running
into mental roadblocks with the current setup.  You need two objects
in play here: one to store the configuration from the user and another
to be the scope that the template source is evaluated against.

I had originally thought I would use `Template` for the config and
_something_ else for the scope.  But as I tried to name the something
I realized the naming was off.  I think `Template` should be the
scope your source file evals against.  It's called a "template file"
after all.

So here I'm thinking the config object should be called a `Render`.
A render builds and renders a template in the correct format.  The
naming seems to flow better with the action and other names involved.

This does the trivial rename of `Template` to `Render`.

@jcredding ready for review.
