### PR TITLE
have templates evaluate given source files

### DIFF
--- a/lib/nm/template.rb
+++ b/lib/nm/template.rb
@@ -6,6 +6,15 @@ module Nm
 
     def initialize(*args)
       @__dstack__ = [ nil ]
+
+      source_file = args.last.to_s
+      return if source_file.empty?
+
+      unless File.exists?(source_file)
+        raise ArgumentError, "source file `#{source_file}` does not exist"
+      end
+      data = File.send(File.respond_to?(:binread) ? :binread : :read, source_file)
+      instance_eval(data, source_file, 1)
     end
 
     def __data__

--- a/test/support/templates/list.nm
+++ b/test/support/templates/list.nm
@@ -1,0 +1,3 @@
+map [1, 2, 3] do |num|
+  node num.to_s, num
+end

--- a/test/support/templates/obj.nm
+++ b/test/support/templates/obj.nm
@@ -1,0 +1,5 @@
+node 'obj' do
+  node 'a', 'Aye'
+  node 'b', 'Bee'
+  node 'c', "See"
+end

--- a/test/support/templates/slideshow.nm
+++ b/test/support/templates/slideshow.nm
@@ -1,0 +1,12 @@
+node 'slideshow' do
+  node 'start_slide', start_slide
+  node 'slides' do
+    map slides do |slide|
+      node 'id',    slide.id
+      node 'title', slide.title
+      node 'image', slide.image_url
+      node 'thumb', slide.thumb_url
+      node 'url',   slide.url
+    end
+  end
+end

--- a/test/unit/template_tests.rb
+++ b/test/unit/template_tests.rb
@@ -118,4 +118,45 @@ class Nm::Template
 
   end
 
+  class SourceTests < UnitTests
+    desc "when init given a source file"
+    setup do
+      @obj_source_file = TEMPLATE_ROOT.join('obj.nm')
+      @exp_obj = {
+        'obj' => {
+          'a' => 'Aye',
+          'b' => 'Bee',
+          'c' => 'See'
+        }
+      }
+
+      @list_source_file = TEMPLATE_ROOT.join('list.nm')
+      @exp_list = [
+        { '1' => 1 },
+        { '2' => 2 },
+        { '3' => 3 }
+      ]
+    end
+
+    should "evaluate the source file" do
+      assert_equal @exp_obj,  Nm::Template.new(@obj_source_file).__data__
+      assert_equal @exp_list, Nm::Template.new(@list_source_file).__data__
+    end
+
+  end
+
+  class NoExistSourceTests < UnitTests
+    desc "when init given a source file that does not exist"
+    setup do
+      @no_exist_source_file = TEMPLATE_ROOT.join('does-not-exist.nm')
+    end
+
+    should "complain that the source does not exist" do
+      assert_raises ArgumentError do
+        Nm::Template.new(@no_exist_source_file)
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
This updates the template class to read and evaluate any given
source file on init.  This allows the user to store templates in
files and have them rendered.

@jcredding ready for review.
