### PR TITLE
apply locals to template scope as reader methods

### DIFF
--- a/lib/nm/template.rb
+++ b/lib/nm/template.rb
@@ -7,6 +7,12 @@ module Nm
     def initialize(*args)
       @__dstack__ = [ nil ]
 
+      # apply any given locals to template scope as methods
+      metaclass = class << self; self; end
+      (args.last.kind_of?(::Hash) ? args.pop : {}).each do |key, value|
+        metaclass.class_eval{ define_method(key){ value } }
+      end
+
       source_file = args.last.to_s
       return if source_file.empty?
 
@@ -21,7 +27,7 @@ module Nm
       @__dstack__.last
     end
 
-    def node(key, value = nil, &block)
+    def __node__(key, value = nil, &block)
       unless @__dstack__[-1].nil? || @__dstack__[-1].is_a?(::Hash)
         raise InvalidError, "invalid `node` call"
       end
@@ -34,10 +40,11 @@ module Nm
       return self
     end
 
-    alias_method :_node, :node
-    alias_method :n, :node
+    alias_method :node,  :__node__
+    alias_method :_node, :__node__
+    alias_method :n,     :__node__
 
-    def map(list, &block)
+    def __map__(list, &block)
       unless list.respond_to?(:map)
         raise ArgumentError, "given list (`#{list.class}`) doesn't respond to `.map`"
       end
@@ -55,8 +62,9 @@ module Nm
       return self
     end
 
-    alias_method :_map, :map
-    alias_method :m, :map
+    alias_method :map,  :__map__
+    alias_method :_map, :__map__
+    alias_method :m,    :__map__
 
   end
 

--- a/test/support/templates/aliases.nm
+++ b/test/support/templates/aliases.nm
@@ -1,0 +1,4 @@
+_map (1..1) do
+  n     'node local value', node
+  _node 'map local value',  map
+end

--- a/test/unit/template_tests.rb
+++ b/test/unit/template_tests.rb
@@ -16,7 +16,7 @@ class Nm::Template
     end
     subject{ @template }
 
-    should have_imeths :__data__
+    should have_imeths :__data__, :__node__, :__map__
     should have_imeths :node, :_node, :n
     should have_imeths :map,  :_map,  :m
 
@@ -24,41 +24,42 @@ class Nm::Template
       assert_nil subject.__data__
     end
 
-    should "return the template with `node` and `map`" do
+    should "return the template with `__node__` and `__map__`" do
       t = Nm::Template.new
-      assert_equal t, t.node('key', 'value')
+      assert_equal t, t.__node__('key', 'value')
 
       t = Nm::Template.new
-      assert_equal t, t.map([], &Proc.new{})
+      assert_equal t, t.__map__([], &Proc.new{})
     end
 
   end
 
   class NodeMethodTests < UnitTests
-    desc "`node` method"
+    desc "`__node__` method"
 
     should "add key-value pairs at any level" do
       exp = {'a' => 'Aye'}
-      assert_equal exp, Nm::Template.new.node('a', 'Aye').__data__
+      assert_equal exp, Nm::Template.new.__node__('a', 'Aye').__data__
 
       exp = {
         'nested' => {'a' => 'Aye'}
       }
-      t = Nm::Template.new.node('nested'){ node('a', 'Aye') }
+      t = Nm::Template.new.__node__('nested'){ __node__('a', 'Aye') }
       assert_equal exp, t.__data__
     end
 
-    should "be aliased as `_node` and `n`" do
+    should "be aliased as `node`, `_node` and `n`" do
       exp = {'a' => 'Aye'}
+      assert_equal exp, Nm::Template.new.__node__('a', 'Aye').__data__
       assert_equal exp, Nm::Template.new.node('a', 'Aye').__data__
       assert_equal exp, Nm::Template.new._node('a', 'Aye').__data__
       assert_equal exp, Nm::Template.new.n('a', 'Aye').__data__
     end
 
-    should "complain if called alongside a `map` call" do
-      t = Nm::Template.new.map([1,2,3])
+    should "complain if called alongside a `__map__` call" do
+      t = Nm::Template.new.__map__([1,2,3])
       assert_raises InvalidError do
-        t.node('a', 'Aye')
+        t.__node__('a', 'Aye')
       end
     end
 
@@ -72,14 +73,14 @@ class Nm::Template
 
     should "map a given list to the data" do
       exp = @list
-      assert_equal exp, Nm::Template.new.map(@list).__data__
+      assert_equal exp, Nm::Template.new.__map__(@list).__data__
 
       exp = [
         {'1' => 1},
         {'2' => 2},
         {'3' => 3},
       ]
-      t = Nm::Template.new.map(@list){ |item| node(item.to_s, item) }
+      t = Nm::Template.new.__map__(@list){ |item| __node__(item.to_s, item) }
       assert_equal exp, t.__data__
 
       exp = {
@@ -90,29 +91,32 @@ class Nm::Template
         ]
       }
       list = @list
-      t = Nm::Template.new.node('list') do
-        map(list){ |item| node(item.to_s, item) }
+      t = Nm::Template.new.__node__('list') do
+        __map__(list){ |item| __node__(item.to_s, item) }
       end
       assert_equal exp, t.__data__
     end
 
-    should "be aliased as `_map` and `m`" do
+    should "be aliased as `map`, `_map` and `m`" do
       exp = @list
+      assert_equal exp, Nm::Template.new.__map__(@list).__data__
       assert_equal exp, Nm::Template.new.map(@list).__data__
       assert_equal exp, Nm::Template.new._map(@list).__data__
       assert_equal exp, Nm::Template.new.m(@list).__data__
     end
 
     should "complain if given a list that doesn't respond to `.map`" do
+      val = 123
+      assert_not_responds_to 'map', val
       assert_raises ArgumentError do
-        Nm::Template.new.map(123)
+        Nm::Template.new.__map__(val)
       end
     end
 
-    should "complain if called alongside a `node` call" do
-      t = Nm::Template.new.node('a', 'Aye')
+    should "complain if called alongside a `__node__` call" do
+      t = Nm::Template.new.__node__('a', 'Aye')
       assert_raises InvalidError do
-        t.map([1,2,3])
+        t.__map__([1,2,3])
       end
     end
 
@@ -143,6 +147,11 @@ class Nm::Template
       assert_equal @exp_list, Nm::Template.new(@list_source_file).__data__
     end
 
+    should "evaluate the source file with locals" do
+      assert_equal @exp_obj,  Nm::Template.new(@obj_source_file,  {}).__data__
+      assert_equal @exp_list, Nm::Template.new(@list_source_file, {}).__data__
+    end
+
   end
 
   class NoExistSourceTests < UnitTests
@@ -155,6 +164,34 @@ class Nm::Template
       assert_raises ArgumentError do
         Nm::Template.new(@no_exist_source_file)
       end
+    end
+
+  end
+
+  class LocalsTests < UnitTests
+    desc "when init with locals"
+    setup do
+      @locals = {
+        'key' => 'value',
+        'node' => 'A Node',
+        'map' => 'A Map'
+      }
+    end
+
+    should "expose the local as a reader method on the template" do
+      t = Nm::Template.new
+      assert_not_responds_to 'key', t
+
+      t = Nm::Template.new(@locals)
+      assert_equal 'value', t.key
+    end
+
+    should "not interfere with method aliases" do
+      d = Nm::Template.new(TEMPLATE_ROOT.join('aliases.nm'), @locals).__data__
+      assert_kind_of ::Array, d
+      assert_equal 1, d.size
+      assert_equal 'A Node', d.first['node local value']
+      assert_equal 'A Map',  d.first['map local value']
     end
 
   end


### PR DESCRIPTION
This updates the template init api to take an optional locals hash.
Any keys in the given hash will be exposed as reader methods on the
template object.  This allows you to pass in custom local values and
use those values as local methods in template source files.

This also validates that if you give a local named after a template
method, you get the local as expected but it doesn't interfere with
the method aliases.

**Note**: this also updates the alias handling of the node and map
methods.  This technically isn't _needed_ but I wanted to highlight
how the "underlying" node/map logic is separate from the way(s) you
can call it via a template.  So now, the main logic is in "underscored"
methods and the available aliases just alias this main method.  This
seemed to flow nicely with the `__data__` method as well.

@jcredding ready for review.
