### PR TITLE
remove "magic underscore" behavior in the `partial` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ node 'slideshow' do
   node 'start_slide', start_slide
   node 'slides' do
     map slides do |slide|
-      partial 'slide.json', :slide => slide
+      partial '_slide.json', :slide => slide
     end
   end
 end

--- a/bench/slideshow_partials.nm
+++ b/bench/slideshow_partials.nm
@@ -2,7 +2,7 @@ node 'slideshow' do
   node 'start_slide', view.start_slide
   node 'slides' do
     map view.slides do |slide|
-      partial 'slide', :slide => slide
+      partial '_slide', :slide => slide
     end
   end
 end

--- a/lib/nm/source.rb
+++ b/lib/nm/source.rb
@@ -21,19 +21,12 @@ module Nm
       Template.new(self, source_file_path(file_name), locals || {}).__data__
     end
 
-    def partial(file_name, locals = nil)
-      Template.new(self, partial_file_path(file_name), locals || {}).__data__
-    end
+    alias_method :partial, :render
 
     private
 
     def source_file_path(file_name)
       self.root.join("#{file_name}#{EXT}").to_s
-    end
-
-    def partial_file_path(file_name)
-      basename = File.basename(file_name.to_s)
-      source_file_path(file_name.to_s.sub(/#{basename}\Z/, "_#{basename}"))
     end
 
   end

--- a/script/bench_all.rb
+++ b/script/bench_all.rb
@@ -2,4 +2,5 @@
 
 require 'script/bench_rabl'
 require 'script/bench_nm'
+require 'script/bench_nm_partials'
 require 'script/bench_nm_re_source'

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -56,19 +56,8 @@ class Nm::Source
       assert_equal exp, subject.render(@file_name, @file_locals)
     end
 
-  end
-
-  class PartialTests < InitTests
-    desc "`partial` method"
-
-    setup do
-      @file_name = "locals"
-      @file_locals = { 'key' => 'a-value' }
-      @file_path = Factory.template_file("_#{@file_name}#{Nm::Source::EXT}")
-    end
-
-    should "render a template for the given file name and return its data" do
-      exp = Nm::Template.new(subject, @file_path, @file_locals).__data__
+    should "alias `render` as `partial`" do
+      exp = subject.render(@file_name, @file_locals)
       assert_equal exp, subject.partial(@file_name, @file_locals)
     end
 

--- a/test/unit/template_tests.rb
+++ b/test/unit/template_tests.rb
@@ -216,31 +216,33 @@ class Nm::Template
   class PartialMethodTests < RenderTests
     desc "`partial` method"
     setup do
+      @partial_obj_file_name = "_obj"
       @partial_obj = {
         'a' => 'Aye',
         'b' => 'Bee',
         'c' => 'See'
       }
+      @partial_list_file_name = "_list"
       @partial_list = @list
     end
 
     should "render a template for the given partial name and add its data" do
       t = Nm::Template.new(@source)
-      assert_equal @partial_obj, t.__partial__(@obj_file_name).__data__
+      assert_equal @partial_obj, t.__partial__(@partial_obj_file_name).__data__
     end
 
     should "be aliased as `render`, `_render` and `r`" do
       t = Nm::Template.new(@source)
-      assert_equal @partial_obj, t.__partial__(@obj_file_name).__data__
+      assert_equal @partial_obj, t.__partial__(@partial_obj_file_name).__data__
 
       t = Nm::Template.new(@source)
-      assert_equal @partial_obj, t.partial(@obj_file_name).__data__
+      assert_equal @partial_obj, t.partial(@partial_obj_file_name).__data__
 
       t = Nm::Template.new(@source)
-      assert_equal @partial_obj, t._partial(@obj_file_name).__data__
+      assert_equal @partial_obj, t._partial(@partial_obj_file_name).__data__
 
       t = Nm::Template.new(@source)
-      assert_equal @partial_obj, t.p(@obj_file_name).__data__
+      assert_equal @partial_obj, t.p(@partial_obj_file_name).__data__
     end
 
     should "merge if call returns an obj and called after a `__node__` call" do
@@ -248,14 +250,14 @@ class Nm::Template
       t.__node__('1', 'One')
 
       exp = {'1' => 'One'}.merge(@partial_obj)
-      assert_equal exp, t.__partial__(@obj_file_name).__data__
+      assert_equal exp, t.__partial__(@partial_obj_file_name).__data__
     end
 
     should "complain if call returns an obj and called after a `__map__` call" do
       t = Nm::Template.new(@source)
       t.__map__([1,2,3])
       assert_raises Nm::InvalidError do
-        t.__partial__(@obj_file_name).__data__
+        t.__partial__(@partial_obj_file_name).__data__
       end
     end
 
@@ -264,7 +266,7 @@ class Nm::Template
       t.__map__([1,2,3])
 
       exp = [1,2,3].concat(@partial_list)
-      assert_equal exp, t.__partial__(@list_file_name).__data__
+      assert_equal exp, t.__partial__(@partial_list_file_name).__data__
     end
 
     should "complain if call returns a list and called after a `__node__` call" do
@@ -272,7 +274,7 @@ class Nm::Template
       t.__node__('1', 'One')
 
       assert_raises Nm::InvalidError do
-        t.__partial__(@list_file_name).__data__
+        t.__partial__(@partial_list_file_name).__data__
       end
     end
 


### PR DESCRIPTION
This switches partial rendering to not magically include a leading
underscore in the file name.  It is simpler and clearer to just make
the user specify the exact file name and if they choose to use the
convention of leading underscores then whatever.

The result is the `partial` method is now just an alias to calling
`render`.

@jcredding ready for review.  Since we removed this in Deas, I want to keep things consistent here too.
