### PR TITLE
switch how locals are applied to template metaclass - an optimization

### DIFF
--- a/bench/results/nm.txt
+++ b/bench/results/nm.txt
@@ -2,29 +2,29 @@ Nm slideshow: 1 times
 ---------------------
 whysoslow? ..
 
-mem @ start             41 MB                   ??
-mem @ finish            41 MB                   [31m+   0 MB,   0%[0m
+mem @ start             44 MB                   ??
+mem @ finish            44 MB                   [31m+   0 MB,   0%[0m
 
          user     system   total    real
-time     0.0 ms   0.0 ms   0.0 ms   5.086 ms
+time     0.0 ms   10.0 ms  10.0 ms  4.796 ms
 
 Nm slideshow: 10 times
 ----------------------
 whysoslow? ..
 
-mem @ start             41 MB                   ??
-mem @ finish            54 MB                   [31m+  13 MB,  32%[0m
+mem @ start             44 MB                   ??
+mem @ finish            55 MB                   [31m+  11 MB,  26%[0m
 
           user      system    total     real
-time      40.0 ms   0.0 ms    40.0 ms   39.215 ms
+time      40.0 ms   10.0 ms   50.0 ms   42.879 ms
 
 Nm slideshow: 100 times
 -----------------------
 whysoslow? ..
 
 mem @ start             54 MB                   ??
-mem @ finish            212 MB                  [31m+ 158 MB, 294%[0m
+mem @ finish            214 MB                  [31m+ 159 MB, 294%[0m
 
            user       system     total      real
-time       320.0 ms   60.0 ms    380.0 ms   379.717 ms
+time       320.0 ms   60.0 ms    380.0 ms   379.385 ms
 

--- a/bench/results/nm_partials.txt
+++ b/bench/results/nm_partials.txt
@@ -2,29 +2,29 @@ Nm slideshow_partials: 1 times
 ------------------------------
 whysoslow? ..
 
-mem @ start             41 MB                   ??
-mem @ finish            41 MB                   [31m+   0 MB,   0%[0m
+mem @ start             40 MB                   ??
+mem @ finish            42 MB                   [31m+   2 MB,   5%[0m
 
           user      system    total     real
-time      20.0 ms   0.0 ms    20.0 ms   20.947 ms
+time      20.0 ms   0.0 ms    20.0 ms   18.724 ms
 
 Nm slideshow_partials: 10 times
 -------------------------------
 whysoslow? ..
 
-mem @ start             41 MB                   ??
-mem @ finish            74 MB                   [31m+  33 MB,  81%[0m
+mem @ start             43 MB                   ??
+mem @ finish            75 MB                   [31m+  32 MB,  75%[0m
 
            user       system     total      real
-time       170.0 ms   30.0 ms    200.0 ms   196.232 ms
+time       150.0 ms   30.0 ms    180.0 ms   177.389 ms
 
 Nm slideshow_partials: 100 times
 --------------------------------
 whysoslow? ..
 
-mem @ start             50 MB                   ??
-mem @ finish            531 MB                  [31m+ 480 MB, 952%[0m
+mem @ start             53 MB                   ??
+mem @ finish            517 MB                  [31m+ 464 MB, 883%[0m
 
-            user        system      total       real
-time        1640.0 ms   310.0 ms    1950.0 ms   1944.464 ms
+          user      system    total     real
+time      1470.0 ms 280.0 ms  1750.0 ms 1755.6 ms
 

--- a/bench/results/nm_re_source.txt
+++ b/bench/results/nm_re_source.txt
@@ -6,25 +6,25 @@ mem @ start             41 MB                   ??
 mem @ finish            41 MB                   [31m+   0 MB,   0%[0m
 
          user     system   total    real
-time     0.0 ms   0.0 ms   0.0 ms   6.727 ms
+time     10.0 ms  0.0 ms   10.0 ms  4.966 ms
 
 Nm slideshow: 10 times
 ----------------------
 whysoslow? ..
 
 mem @ start             41 MB                   ??
-mem @ finish            51 MB                   [31m+  10 MB,  23%[0m
+mem @ finish            53 MB                   [31m+  12 MB,  30%[0m
 
           user      system    total     real
-time      40.0 ms   10.0 ms   50.0 ms   40.104 ms
+time      30.0 ms   10.0 ms   40.0 ms   38.769 ms
 
 Nm slideshow: 100 times
 -----------------------
 whysoslow? ..
 
-mem @ start             50 MB                   ??
-mem @ finish            209 MB                  [31m+ 159 MB, 320%[0m
+mem @ start             53 MB                   ??
+mem @ finish            213 MB                  [31m+ 160 MB, 300%[0m
 
            user       system     total      real
-time       310.0 ms   60.0 ms    370.0 ms   376.581 ms
+time       330.0 ms   60.0 ms    390.0 ms   386.509 ms
 

--- a/bench/results/rabl.txt
+++ b/bench/results/rabl.txt
@@ -2,29 +2,29 @@ RABL slideshow: 1 times
 -----------------------
 whysoslow? ..
 
-mem @ start             40 MB                   ??
-mem @ finish            40 MB                   [31m+   0 MB,   0%[0m
+mem @ start             43 MB                   ??
+mem @ finish            44 MB                   [31m+   1 MB,   2%[0m
 
           user      system    total     real
-time      10.0 ms   0.0 ms    10.0 ms   18.029 ms
+time      20.0 ms   0.0 ms    20.0 ms   24.123 ms
 
 RABL slideshow: 10 times
 ------------------------
 whysoslow? ..
 
-mem @ start             40 MB                   ??
-mem @ finish            85 MB                   [31m+  45 MB, 112%[0m
+mem @ start             44 MB                   ??
+mem @ finish            87 MB                   [31m+  43 MB,  98%[0m
 
-           user       system     total      real
-time       170.0 ms   20.0 ms    190.0 ms   193.534 ms
+          user      system    total     real
+time      150.0 ms  20.0 ms   170.0 ms  178.32 ms
 
 RABL slideshow: 100 times
 -------------------------
 whysoslow? ..
 
 mem @ start             69 MB                   ??
-mem @ finish            458 MB                  [31m+ 389 MB, 565%[0m
+mem @ finish            461 MB                  [31m+ 392 MB, 567%[0m
 
             user        system      total       real
-time        1530.0 ms   190.0 ms    1720.0 ms   1720.782 ms
+time        1480.0 ms   180.0 ms    1660.0 ms   1647.708 ms
 

--- a/lib/nm/template.rb
+++ b/lib/nm/template.rb
@@ -10,18 +10,20 @@ module Nm
 
       # apply any given locals to template scope as methods
       metaclass = class << self; self; end
-      (args.last.kind_of?(::Hash) ? args.pop : {}).each do |key, value|
-        metaclass.class_eval{ define_method(key){ value } }
+      metaclass.class_eval do
+        (args.last.kind_of?(::Hash) ? args.pop : {}).each do |key, value|
+          define_method(key){ value }
+        end
       end
 
       source_file = args.last.kind_of?(::String) ? args.pop : ''
       @__source__ = args.last.kind_of?(Source) ? args.pop : DefaultSource.new
 
       return if source_file.empty?
-
-      unless File.exists?(source_file)
+      if !File.exists?(source_file)
         raise ArgumentError, "source file `#{source_file}` does not exist"
       end
+
       instance_eval(@__source__.data(source_file), source_file, 1)
     end
 


### PR DESCRIPTION
This switches to only calling `class_eval` once while applying the
locals instead of calling it once for every local.

This is just a minor optimization - no behavior changes.  I noticed
this while researching the same concerns for deas-erubis logic.

@jcredding ready for review.
