### PR TITLE
default template locals

### DIFF
--- a/bench/results/nm.txt
+++ b/bench/results/nm.txt
@@ -2,29 +2,29 @@ Nm slideshow: 1 times
 ---------------------
 whysoslow? ..
 
-mem @ start             44 MB                   ??
-mem @ finish            44 MB                   [31m+   0 MB,   0%[0m
+mem @ start             42 MB                   ??
+mem @ finish            42 MB                   [31m+   0 MB,   0%[0m
 
          user     system   total    real
-time     0.0 ms   10.0 ms  10.0 ms  4.796 ms
+time     0.0 ms   0.0 ms   0.0 ms   4.895 ms
 
 Nm slideshow: 10 times
 ----------------------
 whysoslow? ..
 
-mem @ start             44 MB                   ??
-mem @ finish            55 MB                   [31m+  11 MB,  26%[0m
+mem @ start             42 MB                   ??
+mem @ finish            53 MB                   [31m+  11 MB,  26%[0m
 
           user      system    total     real
-time      40.0 ms   10.0 ms   50.0 ms   42.879 ms
+time      30.0 ms   10.0 ms   40.0 ms   39.228 ms
 
 Nm slideshow: 100 times
 -----------------------
 whysoslow? ..
 
-mem @ start             54 MB                   ??
-mem @ finish            214 MB                  [31m+ 159 MB, 294%[0m
+mem @ start             53 MB                   ??
+mem @ finish            210 MB                  [31m+ 157 MB, 295%[0m
 
            user       system     total      real
-time       320.0 ms   60.0 ms    380.0 ms   379.385 ms
+time       320.0 ms   60.0 ms    380.0 ms   382.278 ms
 

--- a/lib/nm/source.rb
+++ b/lib/nm/source.rb
@@ -7,10 +7,13 @@ module Nm
 
     EXT = ".nm"
 
-    attr_reader :root
+    attr_reader :root, :template_class
 
-    def initialize(root)
+    def initialize(root, locals = nil)
       @root = Pathname.new(root.to_s)
+      @template_class = Class.new(Template) do
+        (locals || {}).each{ |key, value| define_method(key){ value } }
+      end
     end
 
     def data(file_path)
@@ -18,7 +21,7 @@ module Nm
     end
 
     def render(file_name, locals = nil)
-      Template.new(self, source_file_path(file_name), locals || {}).__data__
+      @template_class.new(self, source_file_path(file_name), locals || {}).__data__
     end
 
     alias_method :partial, :render

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'nm/source'
 
+require 'nm/template'
+
 class Nm::Source
 
   class UnitTests < Assert::Context
@@ -21,11 +23,24 @@ class Nm::Source
     end
     subject{ @source }
 
-    should have_readers :root
+    should have_readers :root, :template_class
     should have_imeths :data, :render, :partial
 
     should "know its root" do
       assert_equal @root, subject.root.to_s
+    end
+
+    should "know its template class" do
+      assert_true subject.template_class < Nm::Template
+    end
+
+    should "optionally take and apply default locals to its template class" do
+      local_name, local_val = [Factory.string, Factory.string]
+      source = Nm::Source.new(@root, local_name => local_val)
+      template = source.template_class.new
+
+      assert_responds_to local_name, template
+      assert_equal local_val, template.send(local_name)
     end
 
   end


### PR DESCRIPTION
This updates the source to optionally take default template locals.
Locals are applied to an anonymous subclass of `Template` and this
subclass is used to do all source renderings.

The goal here is to apply a local that is used across all renders -
one you don't have to remember to pass in and applies to both top
level renders and partial renders.  Specifically, this will be used
by both the deas and sanford nm adapters to make their `logger`
available in the templates.

@jcredding I realized the logger stuff I did in deas-nm previously won't fully work as the logger won't be available in partial calls.  I had to go deeper and effect the template scope itself.  Thus this feature.  I'll go back and update deas-nm and sanford-nm to take advantage of this in coming PRs.
