### PR TITLE
define custom inspects for both `Source` and `Template`

### DIFF
--- a/lib/nm/source.rb
+++ b/lib/nm/source.rb
@@ -16,6 +16,10 @@ module Nm
       end
     end
 
+    def inspect
+      "#<#{self.class}:#{'0x0%x' % (object_id << 1)} @root=#{@root.inspect}>"
+    end
+
     def data(file_path)
       File.send(File.respond_to?(:binread) ? :binread : :read, file_path)
     end

--- a/lib/nm/template.rb
+++ b/lib/nm/template.rb
@@ -27,6 +27,12 @@ module Nm
       instance_eval(@__source__.data(source_file), source_file, 1)
     end
 
+    def inspect
+      "#<Template:#{@__source__.class}:#{'0x0%x' % (@__source__.object_id << 1)}"\
+      " @__source__.root=#{@__source__.root.to_s.inspect}"\
+      " __data__=#{self.__data__.inspect}>"
+    end
+
     def __data__
       @__dstack__.last
     end


### PR DESCRIPTION
This is just to ease when debugging errors and inspecting values.
There is no need to show the raw instance variables and internal
tracking details.  They are really noisy and don't help much.  Plus
with the template being an anonymous class its inspect was even more
confusing.

For the source object, this switches to only showing the root when
inspecting the source.  This is really all that matters in the
source's state.

For the template object, this switches to displaying the template's
souce class/objid prefixed with `Template:` for the class info.
Each template is bound to it's source so this is a better option than
showing the anonymous class info.  This also just showsthe raw source
path string and what `__data__` would be as this is the only practical
state info on a template.

This is just a cleanup - no behavior changes.

@jcredding ready for review.  Here is what it looks like IRL:

``` ruby
require 'nm/source'
=> true
s = Nm::Source.new('/')
=> #<Nm::Source:0x01078c8360 @root=#<Pathname:/>>
t = s.template_class.new(s)
=> #<Template:Nm::Source:0x01078c8360 @__source__.root="/" __data__=nil>
```
