### PR TITLE
template cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,24 @@ Output:
 
 ## Notes
 
+### Cache Templates
+
+By default the source doesn't cache template files.  You can configure it to cache templates using the `:cache` option:
+
+```ruby
+source = Nm::Source.new('/path/to/views', :cache => true)
+```
+
+### Default locals
+
+You can specify a set of default locals to use on all renders for a source using the `:locals` option:
+
+```ruby
+source = Nm::Source.new('/path/to/views', :locals => {
+  'something' => 'value'
+})
+```
+
 ### Render Format
 
 Rendering templates returns a data object (`::Hash` or `::Array`).  To serialize, bring in your favorite JSON/BSON/whatever serializer and pass the rendered object to it.

--- a/bench/results/nm.txt
+++ b/bench/results/nm.txt
@@ -2,29 +2,29 @@ Nm slideshow: 1 times
 ---------------------
 whysoslow? ..
 
-mem @ start             42 MB                   ??
-mem @ finish            42 MB                   [31m+   0 MB,   0%[0m
+mem @ start             249 MB                  ??
+mem @ finish            250 MB                  [31m+   1 MB,   0%[0m
 
          user     system   total    real
-time     0.0 ms   0.0 ms   0.0 ms   4.895 ms
+time     10.0 ms  0.0 ms   10.0 ms  8.654 ms
 
 Nm slideshow: 10 times
 ----------------------
 whysoslow? ..
 
-mem @ start             42 MB                   ??
-mem @ finish            53 MB                   [31m+  11 MB,  26%[0m
+mem @ start             250 MB                  ??
+mem @ finish            255 MB                  [31m+   5 MB,   2%[0m
 
           user      system    total     real
-time      30.0 ms   10.0 ms   40.0 ms   39.228 ms
+time      40.0 ms   10.0 ms   50.0 ms   41.578 ms
 
 Nm slideshow: 100 times
 -----------------------
 whysoslow? ..
 
-mem @ start             53 MB                   ??
-mem @ finish            210 MB                  [31m+ 157 MB, 295%[0m
+mem @ start             252 MB                  ??
+mem @ finish            404 MB                  [31m+ 152 MB,  61%[0m
 
            user       system     total      real
-time       320.0 ms   60.0 ms    380.0 ms   382.278 ms
+time       340.0 ms   60.0 ms    400.0 ms   392.771 ms
 

--- a/bench/results/nm_partials.txt
+++ b/bench/results/nm_partials.txt
@@ -2,29 +2,29 @@ Nm slideshow_partials: 1 times
 ------------------------------
 whysoslow? ..
 
-mem @ start             40 MB                   ??
-mem @ finish            42 MB                   [31m+   2 MB,   5%[0m
+mem @ start             253 MB                  ??
+mem @ finish            254 MB                  [31m+   1 MB,   0%[0m
 
-          user      system    total     real
-time      20.0 ms   0.0 ms    20.0 ms   18.724 ms
+         user     system   total    real
+time     20.0 ms  0.0 ms   20.0 ms  24.11 ms
 
 Nm slideshow_partials: 10 times
 -------------------------------
 whysoslow? ..
 
-mem @ start             43 MB                   ??
-mem @ finish            75 MB                   [31m+  32 MB,  75%[0m
+mem @ start             254 MB                  ??
+mem @ finish            278 MB                  [31m+  24 MB,   9%[0m
 
            user       system     total      real
-time       150.0 ms   30.0 ms    180.0 ms   177.389 ms
+time       150.0 ms   10.0 ms    160.0 ms   167.136 ms
 
 Nm slideshow_partials: 100 times
 --------------------------------
 whysoslow? ..
 
-mem @ start             53 MB                   ??
-mem @ finish            517 MB                  [31m+ 464 MB, 883%[0m
+mem @ start             254 MB                  ??
+mem @ finish            798 MB                  [31m+ 544 MB, 214%[0m
 
-          user      system    total     real
-time      1470.0 ms 280.0 ms  1750.0 ms 1755.6 ms
+            user        system      total       real
+time        1500.0 ms   240.0 ms    1740.0 ms   1740.444 ms
 

--- a/bench/results/nm_re_source.txt
+++ b/bench/results/nm_re_source.txt
@@ -1,30 +1,30 @@
-Nm slideshow: 1 times
----------------------
+Nm (re-source) slideshow: 1 times
+---------------------------------
 whysoslow? ..
 
-mem @ start             41 MB                   ??
-mem @ finish            41 MB                   [31m+   0 MB,   0%[0m
+mem @ start             425 MB                  ??
+mem @ finish            426 MB                  [31m+   1 MB,   0%[0m
 
          user     system   total    real
-time     10.0 ms  0.0 ms   10.0 ms  4.966 ms
+time     0.0 ms   0.0 ms   0.0 ms   8.699 ms
 
-Nm slideshow: 10 times
-----------------------
+Nm (re-source) slideshow: 10 times
+----------------------------------
 whysoslow? ..
 
-mem @ start             41 MB                   ??
-mem @ finish            53 MB                   [31m+  12 MB,  30%[0m
+mem @ start             252 MB                  ??
+mem @ finish            256 MB                  [31m+   5 MB,   2%[0m
 
           user      system    total     real
-time      30.0 ms   10.0 ms   40.0 ms   38.769 ms
+time      30.0 ms   10.0 ms   40.0 ms   41.577 ms
 
-Nm slideshow: 100 times
------------------------
+Nm (re-source) slideshow: 100 times
+-----------------------------------
 whysoslow? ..
 
-mem @ start             53 MB                   ??
-mem @ finish            213 MB                  [31m+ 160 MB, 300%[0m
+mem @ start             253 MB                  ??
+mem @ finish            401 MB                  [31m+ 148 MB,  58%[0m
 
-           user       system     total      real
-time       330.0 ms   60.0 ms    390.0 ms   386.509 ms
+          user      system    total     real
+time      370.0 ms  70.0 ms   440.0 ms  440.59 ms
 

--- a/bench/results/rabl.txt
+++ b/bench/results/rabl.txt
@@ -3,28 +3,28 @@ RABL slideshow: 1 times
 whysoslow? ..
 
 mem @ start             43 MB                   ??
-mem @ finish            44 MB                   [31m+   1 MB,   2%[0m
+mem @ finish            43 MB                   [31m+   0 MB,   0%[0m
 
           user      system    total     real
-time      20.0 ms   0.0 ms    20.0 ms   24.123 ms
+time      20.0 ms   0.0 ms    20.0 ms   18.494 ms
 
 RABL slideshow: 10 times
 ------------------------
 whysoslow? ..
 
-mem @ start             44 MB                   ??
-mem @ finish            87 MB                   [31m+  43 MB,  98%[0m
+mem @ start             43 MB                   ??
+mem @ finish            88 MB                   [31m+  45 MB, 104%[0m
 
-          user      system    total     real
-time      150.0 ms  20.0 ms   170.0 ms  178.32 ms
+           user       system     total      real
+time       170.0 ms   20.0 ms    190.0 ms   198.726 ms
 
 RABL slideshow: 100 times
 -------------------------
 whysoslow? ..
 
-mem @ start             69 MB                   ??
-mem @ finish            461 MB                  [31m+ 392 MB, 567%[0m
+mem @ start             68 MB                   ??
+mem @ finish            575 MB                  [31m+ 506 MB, 739%[0m
 
             user        system      total       real
-time        1480.0 ms   180.0 ms    1660.0 ms   1647.708 ms
+time        1550.0 ms   220.0 ms    1770.0 ms   1767.589 ms
 

--- a/bench/runner.rb
+++ b/bench/runner.rb
@@ -59,7 +59,7 @@ module NmBench
 
     def initialize(template_name, printer_io, num_times = 10)
       template = Template.find(template_name)
-      source = Nm::Source.new(File.expand_path('..', __FILE__))
+      source = Nm::Source.new(File.expand_path('..', __FILE__), :cache => true)
       super(printer_io, "Nm #{template.name}", num_times) do
         out = source.render(template.name, template.locals)
       end
@@ -73,8 +73,8 @@ module NmBench
 
     def initialize(template_name, printer_io, num_times = 10)
       template = Template.find(template_name)
-      super(printer_io, "Nm #{template.name}", num_times) do
-        source = Nm::Source.new(File.expand_path('..', __FILE__))
+      super(printer_io, "Nm (re-source) #{template.name}", num_times) do
+        source = Nm::Source.new(File.expand_path('..', __FILE__), :cache => true)
         out = source.render(template.name, template.locals)
       end
     end


### PR DESCRIPTION
This adds logic to the source to enable template caching.  This
shows a modest improvement in the benchmarks relative to not caching.

To accomplish this, I had to update the source api to take options
rather than default locals directly.  This also updates the the
README to document the cache option as well as the default locals
option.

@jcredding ready for review.