### PR TITLE
don't require that templates end in a `.nm` extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,7 @@ This will render the same output as above.
 
 ### Markup Aliases
 
-If you find you need to use a local named `node` or `map`, these markup methods are aliased as
-`n`, `_node`, `m`, and `_map` respectively.  Any combination of aliases is valid:
+If you find you need to use a local named `node` or `map`, the markup methods are aliased as `n`, `_node`, `m`, and `_map` respectively.  Any combination of aliases is valid:
 
 ```ruby
 node 'slideshow' do

--- a/lib/nm/source.rb
+++ b/lib/nm/source.rb
@@ -5,8 +5,6 @@ module Nm
 
   class Source
 
-    EXT = ".nm"
-
     attr_reader :root, :cache, :template_class
 
     def initialize(root, opts = nil)
@@ -38,7 +36,7 @@ module Nm
     private
 
     def source_file_path(template_name)
-      self.root.join("#{template_name}#{EXT}").to_s
+      Dir.glob(self.root.join("#{template_name}*")).first
     end
 
     class NullCache

--- a/test/support/templates/locals_alt.inem
+++ b/test/support/templates/locals_alt.inem
@@ -1,0 +1,3 @@
+node 'locals' do
+  node 'key', key
+end

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -12,10 +12,6 @@ class Nm::Source
     end
     subject{ @source_class }
 
-    should "know its extension" do
-      assert_equal ".nm", subject::EXT
-    end
-
   end
 
   class InitTests < UnitTests
@@ -88,9 +84,9 @@ class Nm::Source
   class RenderTests < InitTests
     desc "`render` method"
     setup do
-      @template_name = "locals"
+      @template_name = ['locals', 'locals_alt'].choice
       @file_locals = { 'key' => 'a-value' }
-      @file_path = Factory.template_file("#{@template_name}#{@source_class::EXT}")
+      @file_path = Dir.glob("#{Factory.template_file(@template_name)}*").first
     end
 
     should "render a template for the given template name and return its data" do


### PR DESCRIPTION
At this low-level, nm shouldn't be in the business of demanding
that template files end in any one extension.  If Nm is asked to
render a named template, it should just render it.

Note: the motivation for this change came from updating Deas to
support multi-engine extensions on template files.  Via deas-nm
(and also sanford-nm too), developers can configure nm to render
templates for any extension they choose - Nm should honor that.

See redding/deas#205 for reference.

/cc @jcredding 