### PR TITLE
make template renders return and empty object by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,29 @@ There are two main markup methods:
 * `node`: create a named attribute on a hash object
 * `map`: create a list object mapped from a given list
 
+### Default render value
+
+Nm templates render an empty object (ie `::Hash.new`) if no source is given or no markup methods are called in the template source.  The idea is that the templates should always return *something* and avoid `nil` values as much as possible.
+
+This is also more consistent with rendering mapped lists vs reduced objects.  Say your are mapping a list of objects in your template (using the `map` markup method):
+
+```ruby
+map incoming_list do |item|
+  node 'name',  item.name
+  node 'value', item.value
+end
+```
+
+If there are no items in the incoming list, the template render produces an empty list.  Now say you are reducing an incoming list to a single object:
+
+```ruby
+incoming_list.each do |item|
+  node item.name, item.value
+end
+```
+
+If there are no items in the incoming list, no markup methods are called, but the template render still produces an empty object b/c that is the default value.
+
 ### Partials
 
 **Note**: using partials negatively impacts template rendering performance.

--- a/lib/nm/template.rb
+++ b/lib/nm/template.rb
@@ -6,7 +6,7 @@ module Nm
  class Template
 
     def initialize(*args)
-      @__dstack__ = [ nil ]
+      @__dstack__ = [nil]
 
       # apply any given locals to template scope as methods
       metaclass = class << self; self; end
@@ -34,7 +34,7 @@ module Nm
     end
 
     def __data__
-      @__dstack__.last
+      @__dstack__.last || ::Hash.new
     end
 
     def __node__(key, value = nil, &block)

--- a/test/unit/template_tests.rb
+++ b/test/unit/template_tests.rb
@@ -25,8 +25,8 @@ class Nm::Template
     should have_imeths :render,  :_render,  :r
     should have_imeths :partial, :_partial, :p
 
-    should "have no data if no source file is given" do
-      assert_nil subject.__data__
+    should "have empty data if no markup meths called or no source given" do
+      assert_equal ::Hash.new, subject.__data__
     end
 
     should "return itself when its markup methods are called" do


### PR DESCRIPTION
The idea is that the templates should always return *something*
and avoid `nil` values as much as possible.  This is also more
consistent with rendering mapped lists vs reduced objects.

See the README changes for a more detailed explanation.

@jcredding ready for review.