### PR TITLE
prep for reworking template rendering to support e.g. Rails rendering

### DIFF
--- a/lib/nm/ext.rb
+++ b/lib/nm/ext.rb
@@ -6,19 +6,19 @@ module Nm
 end
 
 class ::Hash
-  def __nm_add_call_data__(call_name, data)
-    raise Nm::InvalidError, "invalid `#{call_name}` call" if data.is_a?(::Array)
+  def __nm_add_partial_data__(data)
+    raise Nm::InvalidError, "invalid partial call" if data.is_a?(::Array)
     merge(data || {})
   end
 end
 
 class ::Array
-  def __nm_add_call_data__(call_name, data)
-    raise Nm::InvalidError, "invalid `#{call_name}` call" if data.is_a?(::Hash)
+  def __nm_add_partial_data__(data)
+    raise Nm::InvalidError, "invalid partial call" if data.is_a?(::Hash)
     concat(data || [])
   end
 end
 
-def nil.__nm_add_call_data__(_call_name, data)
+def nil.__nm_add_partial_data__(data)
   data
 end

--- a/lib/nm/source.rb
+++ b/lib/nm/source.rb
@@ -6,17 +6,17 @@ require "nm/template"
 module Nm; end
 
 class Nm::Source
-  attr_reader :root, :ext, :cache, :template_class
+  attr_reader :root, :extension, :cache, :template_class
 
-  def initialize(root, opts = nil)
+  def initialize(root, extension: nil, cache: false, locals: {})
     opts ||= {}
     @root = Pathname.new(root.to_s)
-    @ext = opts[:ext] ? ".#{opts[:ext]}" : nil
-    @cache = opts[:cache] ? {} : NullCache.new
+    @extension = extension ? ".#{extension}" : nil
+    @cache = cache ? {} : NullCache.new
 
     @template_class =
       Class.new(Nm::Template) do
-        (opts[:locals] || {}).each{ |key, value| define_method(key){ value } }
+        locals.to_h.each{ |key, value| define_method(key){ value } }
       end
   end
 
@@ -31,13 +31,15 @@ class Nm::Source
       end
   end
 
-  def render(template_name, locals = nil)
+  def render(template_name, locals = {})
     if (filename = source_file_path(template_name)).nil?
-      template_desc = "a template file named #{template_name.inspect}"
-      template_desc += " that ends in #{@ext.inspect}" unless @ext.nil?
-      raise ArgumentError, "#{template_desc} does not exist"
+      message  = "a template file named #{template_name.inspect}"
+      message += " that ends in #{@extension.inspect}" unless @extension.nil?
+      message += " does not exist"
+      raise ArgumentError, message
     end
-    @template_class.new(self, filename, locals || {}).__data__
+
+    @template_class.new(self, filename, locals.to_h).__data__
   end
 
   alias_method :partial, :render
@@ -49,7 +51,11 @@ class Nm::Source
   end
 
   def source_file_glob_string(name)
-    !@ext.nil? && name.end_with?(@ext) ? name : "#{name}*#{@ext}"
+    if !@extension.nil? && name.end_with?(@extension)
+      name
+    else
+      "#{name}*#{@extension}"
+    end
   end
 
   class NullCache

--- a/lib/nm/source.rb
+++ b/lib/nm/source.rb
@@ -32,29 +32,32 @@ class Nm::Source
   end
 
   def render(template_name, locals = {})
-    if (filename = source_file_path(template_name)).nil?
+    @template_class.new(self, file_path!(template_name), locals.to_h).__data__
+  end
+
+  alias_method :partial, :render
+
+  def file_path!(template_name)
+    if (path = file_path(template_name)).nil?
       message  = "a template file named #{template_name.inspect}"
       message += " that ends in #{@extension.inspect}" unless @extension.nil?
       message += " does not exist"
       raise ArgumentError, message
     end
-
-    @template_class.new(self, filename, locals.to_h).__data__
+    path
   end
-
-  alias_method :partial, :render
 
   private
 
-  def source_file_path(name)
-    Dir.glob(root.join(source_file_glob_string(name))).first
+  def file_path(template_name)
+    Dir.glob(root.join(file_glob_string(template_name))).first
   end
 
-  def source_file_glob_string(name)
-    if !@extension.nil? && name.end_with?(@extension)
-      name
+  def file_glob_string(template_name)
+    if !@extension.nil? && template_name.end_with?(@extension)
+      template_name
     else
-      "#{name}*#{@extension}"
+      "#{template_name}*#{@extension}"
     end
   end
 

--- a/lib/nm/template.rb
+++ b/lib/nm/template.rb
@@ -81,20 +81,9 @@ class Nm::Template
   alias_method :_map, :__map__
   alias_method :m,    :__map__
 
-  def __render__(*args)
-    data = @__source__.render(*args)
-    @__dstack__[-1] = @__dstack__[-1].__nm_add_call_data__("render", data)
-
-    self
-  end
-
-  alias_method :render,  :__render__
-  alias_method :_render, :__render__
-  alias_method :r,       :__render__
-
   def __partial__(*args)
-    data = @__source__.partial(*args)
-    @__dstack__[-1] = @__dstack__[-1].__nm_add_call_data__("partial", data)
+    @__dstack__[-1] =
+      @__dstack__[-1].__nm_add_partial_data__(@__source__.partial(*args))
 
     self
   end

--- a/test/unit/ext_tests.rb
+++ b/test/unit/ext_tests.rb
@@ -14,20 +14,18 @@ module Nm::Ext
   end
 
   class AddCallDataTests < UnitTests
-    desc "__nm_add_call_data__"
-
-    let(:call_name){ Factory.string }
+    desc "__nm_add_partial_data__"
 
     should "be added to ::Hash" do
-      assert_that({}).responds_to(:__nm_add_call_data__)
+      assert_that({}).responds_to(:__nm_add_partial_data__)
     end
 
     should "be added to ::Array" do
-      assert_that([]).responds_to(:__nm_add_call_data__)
+      assert_that([]).responds_to(:__nm_add_partial_data__)
     end
 
     should "be added to nil" do
-      assert_that(nil).responds_to(:__nm_add_call_data__)
+      assert_that(nil).responds_to(:__nm_add_partial_data__)
     end
   end
 
@@ -38,14 +36,13 @@ module Nm::Ext
 
     should "merge and return hash and nil data" do
       add = { 2 => "2" }
-      assert_that(h.__nm_add_call_data__(call_name, add)).equals(h.merge(add))
-      assert_that(h.__nm_add_call_data__(call_name, nil)).equals(h)
+      assert_that(h.__nm_add_partial_data__(add)).equals(h.merge(add))
+      assert_that(h.__nm_add_partial_data__(nil)).equals(h)
     end
 
     should "complain if adding Array data" do
       add = []
-      assert_that{ h.__nm_add_call_data__(call_name, add) }
-        .raises(Nm::InvalidError)
+      assert_that{ h.__nm_add_partial_data__(add) }.raises(Nm::InvalidError)
     end
   end
 
@@ -56,14 +53,13 @@ module Nm::Ext
 
     should "concat and return array and nil data" do
       add = [3, 4]
-      assert_that(a.__nm_add_call_data__(call_name, add)).equals(a.concat(add))
-      assert_that(a.__nm_add_call_data__(call_name, nil)).equals(a)
+      assert_that(a.__nm_add_partial_data__(add)).equals(a.concat(add))
+      assert_that(a.__nm_add_partial_data__(nil)).equals(a)
     end
 
     should "complain if adding Hash data" do
       add = {}
-      assert_that{ a.__nm_add_call_data__(call_name, add) }
-        .raises(Nm::InvalidError)
+      assert_that{ a.__nm_add_partial_data__(add) }.raises(Nm::InvalidError)
     end
   end
 
@@ -75,10 +71,9 @@ module Nm::Ext
     should "return any given data" do
       add_hash = { 1 => "1" }
       add_array = [3, 4]
-      assert_that(n.__nm_add_call_data__(call_name, add_hash)).equals(add_hash)
-      assert_that(n.__nm_add_call_data__(call_name, add_array))
-        .equals(add_array)
-      assert_that(n.__nm_add_call_data__(call_name, nil)).equals(n)
+      assert_that(n.__nm_add_partial_data__(add_hash)).equals(add_hash)
+      assert_that(n.__nm_add_partial_data__(add_array)).equals(add_array)
+      assert_that(n.__nm_add_partial_data__(nil)).equals(n)
     end
   end
 end

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -21,7 +21,7 @@ class Nm::Source
     let(:source){ unit_class.new(root) }
 
     should have_readers :root, :extension, :cache, :template_class
-    should have_imeths :data, :render, :partial
+    should have_imeths :data, :render, :partial, :file_path!
 
     should "know its root" do
       assert_that(subject.root.to_s).equals(root)
@@ -125,6 +125,23 @@ class Nm::Source
       ["locals_alt", "locals_alt.data", "locals_alt.data.inem"].each do |name|
         assert_that{ source.render(name, file_locals) }.raises(ArgumentError)
       end
+    end
+  end
+
+  class FilePathBangTests < InitTests
+    desc "`file_path!` method"
+
+    let(:template_name){ ["locals", "locals_alt"].sample }
+    let(:file_path) do
+      Dir.glob("#{Factory.template_file(template_name)}*").first
+    end
+
+    should "return the file path for the given template name if it exists" do
+      assert_that(subject.file_path!(template_name)).equals(file_path)
+    end
+
+    should "complain if the given template name does not exist" do
+      assert_that{ subject.file_path!(Factory.path) }.raises(ArgumentError)
     end
   end
 

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -20,7 +20,7 @@ class Nm::Source
     let(:root){ Factory.template_root }
     let(:source){ unit_class.new(root) }
 
-    should have_readers :root, :ext, :cache, :template_class
+    should have_readers :root, :extension, :cache, :template_class
     should have_imeths :data, :render, :partial
 
     should "know its root" do
@@ -28,11 +28,11 @@ class Nm::Source
     end
 
     should "know its extension for looking up source files" do
-      assert_that(subject.ext).is_nil
+      assert_that(subject.extension).is_nil
 
-      ext = Factory.string
-      source = unit_class.new(root, ext: ext)
-      assert_that(source.ext).equals(".#{ext}")
+      extension = Factory.string
+      source = unit_class.new(root, extension: extension)
+      assert_that(source.extension).equals(".#{extension}")
     end
 
     should "not cache templates by default" do
@@ -100,15 +100,15 @@ class Nm::Source
         .equals(subject.render(template_name, file_locals))
     end
 
-    should "only render templates with the matching ext if one is specified" do
-      source = unit_class.new(root, ext: "nm")
+    should "only render templates with the matching extension if one is specified" do
+      source = unit_class.new(root, extension: "nm")
       file_path = Factory.template_file("locals.nm")
       ["locals", "locals.nm"].each do |name|
         assert_that(source.render(name, file_locals))
           .equals(Nm::Template.new(source, file_path, file_locals).__data__)
       end
 
-      source = unit_class.new(root, ext: "inem")
+      source = unit_class.new(root, extension: "inem")
       file_path = Factory.template_file("locals_alt.data.inem")
       ["locals", "locals_alt", "locals_alt.data", "locals_alt.data.inem"]
         .each do |name|
@@ -116,12 +116,12 @@ class Nm::Source
             .equals(Nm::Template.new(source, file_path, file_locals).__data__)
         end
 
-      source = unit_class.new(root, ext: "nm")
+      source = unit_class.new(root, extension: "nm")
       ["locals_alt", "locals_alt.data", "locals_alt.data.inem"].each do |name|
         assert_that{ source.render(name, file_locals) }.raises(ArgumentError)
       end
 
-      source = unit_class.new(root, ext: "data")
+      source = unit_class.new(root, extension: "data")
       ["locals_alt", "locals_alt.data", "locals_alt.data.inem"].each do |name|
         assert_that{ source.render(name, file_locals) }.raises(ArgumentError)
       end

--- a/test/unit/template_tests.rb
+++ b/test/unit/template_tests.rb
@@ -18,10 +18,9 @@ class Nm::Template
     desc "when init"
     subject{ unit_class.new }
 
-    should have_imeths :__data__, :__node__, :__map__, :__render__, :__partial__
+    should have_imeths :__data__, :__node__, :__map__, :__partial__
     should have_imeths :node, :_node, :n
     should have_imeths :map,  :_map,  :m
-    should have_imeths :render,  :_render,  :r
     should have_imeths :partial, :_partial, :p
 
     should "have empty data if no markup meths called or no source given" do
@@ -34,9 +33,6 @@ class Nm::Template
 
       t = Nm::Template.new
       assert_that(t.__map__([], &Proc.new{})).equals(t)
-
-      t = Nm::Template.new
-      assert_that(t.__render__(Factory.template_file("obj"))).equals(t)
 
       t = Nm::Template.new
       assert_that(t.__partial__(Factory.template_file("obj"))).equals(t)
@@ -121,7 +117,9 @@ class Nm::Template
     end
   end
 
-  class RenderTests < InitTests
+  class PartialMethodTests < InitTests
+    desc "`partial` method"
+
     let(:source){ Nm::Source.new(Factory.template_root) }
     let(:obj_template_name){ "obj" }
     let(:obj) do
@@ -141,65 +139,6 @@ class Nm::Template
         { "3" => 3 },
       ]
     end
-  end
-
-  class RenderMethodTests < RenderTests
-    desc "`render` method"
-
-    should "render a template for the given template name and add its data" do
-      t = Nm::Template.new(source)
-      assert_that(t.__render__(obj_template_name).__data__).equals(obj)
-    end
-
-    should "be aliased as `render`, `_render` and `r`" do
-      t = Nm::Template.new(source)
-      assert_that(t.__render__(obj_template_name).__data__).equals(obj)
-
-      t = Nm::Template.new(source)
-      assert_that(t.render(obj_template_name).__data__).equals(obj)
-
-      t = Nm::Template.new(source)
-      assert_that(t._render(obj_template_name).__data__).equals(obj)
-
-      t = Nm::Template.new(source)
-      assert_that(t.r(obj_template_name).__data__).equals(obj)
-    end
-
-    should "merge if call returns an obj and called after `__node__`" do
-      t = Nm::Template.new(source)
-      t.__node__("1", "One")
-
-      exp = { "1" => "One" }.merge(obj)
-      assert_that(t.__render__(obj_template_name).__data__).equals(exp)
-    end
-
-    should "complain if call returns an obj and called after `__map__`" do
-      t = Nm::Template.new(source)
-      t.__map__([1, 2, 3])
-      assert_that{ t.__render__(obj_template_name).__data__ }
-        .raises(Nm::InvalidError)
-    end
-
-    should "concat if call returns a list and called after `__map__`" do
-      t = Nm::Template.new(source)
-      t.__map__([1, 2, 3])
-
-      exp = [1, 2, 3].concat(list)
-      assert_that(t.__render__(list_template_name).__data__).equals(exp)
-    end
-
-    should "complain if call returns a list and called after `__node__`" do
-      t = Nm::Template.new(source)
-      t.__node__("1", "One")
-
-      assert_that{ t.__render__(list_template_name).__data__ }
-        .raises(Nm::InvalidError)
-    end
-  end
-
-  class PartialMethodTests < RenderTests
-    desc "`partial` method"
-
     let(:partial_obj_template_name){ "_obj" }
     let(:partial_obj) do
       {


### PR DESCRIPTION
### remove render Template methods

This not only simplifies the template API but also paves the way
for allowing Nm to work with Rails templates. Rails templates have
their own `render` method that needs to be honored. E.g. we need
to support rendering HTML partials as node values in Nm JSON
templates.

The Nm `render` method wasn't formally documented and existed only
out of convenience.

### rework Source to use keyword arguments; tweak argument handling

This is just some minor updates to modernize how arguments are
passed to the Source object. The only significant change is I've
renamed the `.ext` reader to `.extension` to formally spell out the
property name. I did this to be less cryptic in the API which is
our modern convention when possible/practical.

### add Nm::Source file_path! method

This sets up calling this logic from outside of the Source class.
This will be needed in a coming effort where I rework how template
contexts are handled to support e.g. rendering Nm templates in
Rails's template engine.
