### PR TITLE
add `render_content` method to Nm::Context

### DIFF
--- a/lib/nm/context.rb
+++ b/lib/nm/context.rb
@@ -23,17 +23,24 @@ class Nm::Context
 
   def render(template_name, locals = {})
     source_file_path = @source.file_path!(template_name)
+    render_content(
+      @source.data(source_file_path),
+      locals: locals,
+      file_path: source_file_path,
+    )
+  end
 
+  alias_method :partial, :render
+
+  def render_content(content, locals: {}, file_path: nil)
     @context.__nm_push_render__(locals.to_h)
     @context.instance_eval(
-      "#{locals_code_for(locals)};#{@source.data(source_file_path)}",
-      source_file_path,
+      "#{locals_code_for(locals)};#{content}",
+      file_path,
       1,
     )
     @context.__nm_data__.tap{ |_data| @context.__nm_pop_render__ }
   end
-
-  alias_method :partial, :render
 
   private
 

--- a/lib/nm/source.rb
+++ b/lib/nm/source.rb
@@ -42,6 +42,15 @@ class Nm::Source
     path
   end
 
+  def ==(other)
+    return super unless other.is_a?(self.class)
+
+    root == other.root &&
+    extension == other.extension &&
+    cache == other.cache &&
+    locals == other.locals
+  end
+
   private
 
   def file_path(template_name)
@@ -65,6 +74,10 @@ class Nm::Source
 
     def keys
       []
+    end
+
+    def ==(other)
+      other.is_a?(self.class)
     end
   end
 end

--- a/test/unit/context_tests.rb
+++ b/test/unit/context_tests.rb
@@ -23,7 +23,7 @@ class Nm::Context
     let(:source){ Nm::Source.new(template_root) }
     let(:locals){ { "key" => "a-value" } }
 
-    should have_imeths :render, :partial
+    should have_imeths :render, :partial, :render_content
 
     should "setup the context to render Nm templates" do
       local_name, local_val = [Factory.string, Factory.string]


### PR DESCRIPTION
This method is used to render raw template content strings and is
composed by the `render` method that takes a template path. This
keeps things DRY while adding a more flexible API.

Specifically, this is needed to implement render Nm templates in
Rails' template engine.

I also added some equality methods to ease testing in the rails-nm
gem that I'm working on.
